### PR TITLE
fix: apply active styles to navigation links

### DIFF
--- a/components/molecule/ActiveLink.tsx
+++ b/components/molecule/ActiveLink.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ReactNode, useEffect, useState } from "react";
 import clsx from "clsx";
@@ -29,7 +30,9 @@ export default function ActiveLink({ href, children }: ActiveLinkProps) {
   }, []);
 
   return (
-    <span
+    <Link
+      href={href}
+      aria-current={isActive ? "page" : undefined}
       className={clsx(
         "block rounded-md px-3 py-2 font-medium text-gray-500",
         isMobile ? "text-base" : "text-sm",
@@ -37,6 +40,6 @@ export default function ActiveLink({ href, children }: ActiveLinkProps) {
       )}
     >
       {children}
-    </span>
+    </Link>
   );
 }

--- a/components/molecule/NavLink.tsx
+++ b/components/molecule/NavLink.tsx
@@ -1,6 +1,5 @@
-import Link from "next/link";
 import { ReactNode } from "react";
-import ActiveLink from "@/components/molecule/ActiveLink"; // Подключаем клиентский компонент
+import ActiveLink from "@/components/molecule/ActiveLink";
 
 interface NavLinkProps {
   href: string;
@@ -8,9 +7,5 @@ interface NavLinkProps {
 }
 
 export default function NavLink({ href, children }: NavLinkProps) {
-  return (
-    <Link href={href} className="">
-      <ActiveLink href={href}>{children}</ActiveLink>
-    </Link>
-  );
+  return <ActiveLink href={href}>{children}</ActiveLink>;
 }


### PR DESCRIPTION
## Summary
- render navigation link as a single `<Link>` element with active classes and `aria-current`
- simplify `NavLink` to delegate to `ActiveLink`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5daf7cafc8328b61362ad55877fd9