### PR TITLE
use redux selectors instead of local state in client and about pages

### DIFF
--- a/app/about/clientPage.tsx
+++ b/app/about/clientPage.tsx
@@ -3,24 +3,20 @@
 import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "@/store/store";
 import { increment, decrement, setValue } from "@/store/features/someSlice";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 export default function ClientPage({ initialValue }: { initialValue: number }) {
     const dispatch = useDispatch();
     const reduxValue = useSelector((state: RootState) => state.some.value);
 
-    // Локальный стейт для отображения серверных данных перед обновлением из Redux
-    const [clientValue, setClientValue] = useState(initialValue);
-
-    // После монтирования компонента обновляем значение из Redux
     useEffect(() => {
-        setClientValue(reduxValue);
-    }, [reduxValue]);
+        dispatch(setValue(initialValue));
+    }, [dispatch, initialValue]);
 
     return (
         <div>
             <h1>О нас</h1>
-            <h2>{clientValue}</h2>
+            <h2>{reduxValue ?? initialValue}</h2>
             <button onClick={() => dispatch(increment())}>+</button>
             <button onClick={() => dispatch(decrement())}>-</button>
             <button onClick={() => dispatch(setValue(10))}>Set to 10</button>

--- a/app/clientPage.tsx
+++ b/app/clientPage.tsx
@@ -6,28 +6,16 @@ import { InitialState } from './page';
 import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "@/store/store";
 import { setPaintings } from "@/store/features/paintingsSlice";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 export default function ClientPage({ initialState }: { initialState: InitialState }) {
   const dispatch = useDispatch();
   const reduxList = useSelector((state: RootState) => state.paintings.list);
   const selectedPainting = useSelector((state: RootState) => state.paintings.selectedPainting);
 
-  const [clientList, setClientList] = useState(initialState.paintings);
-  const [clientSelectedPainting, setClientSelectedPainting] = useState(initialState.paintings[0]);
-
   useEffect(() => {
     dispatch(setPaintings(initialState.paintings));
   }, [dispatch, initialState.paintings]);
-
-
-  useEffect(() => {
-    setClientList(reduxList);
-  }, [reduxList]);
-
-  useEffect(() => {
-    setClientSelectedPainting(selectedPainting ?? initialState.paintings[0]);
-  }, [selectedPainting, initialState.paintings]);
 
 
   // fetch("/api/hello")
@@ -40,7 +28,7 @@ export default function ClientPage({ initialState }: { initialState: InitialStat
 
         {/* left side (paintings list ) */}
         <div className="h-full w-45 overflow-auto scrollbar-hide">
-          {clientList.map((painting, i) => (
+          {(reduxList.length ? reduxList : initialState.paintings).map((painting, i) => (
             <PaintingPreview key={painting.title + i} data={painting} />
           ))}
         </div>
@@ -49,17 +37,17 @@ export default function ClientPage({ initialState }: { initialState: InitialStat
         <div className="h-full w-full overflow-auto scrollbar-hide">
 
           {/* top content (img) */}
-          <Painting data={clientSelectedPainting} />
+          <Painting data={selectedPainting ?? initialState.paintings[0]} />
 
           {/* bottom content (info) */}
           <div className="bg-gray-600 p-4 rounded-lg shadow-lg">
-            <div><b>{clientSelectedPainting.title}</b></div>
-            <div>{clientSelectedPainting.description}</div>
+            <div><b>{(selectedPainting ?? initialState.paintings[0]).title}</b></div>
+            <div>{(selectedPainting ?? initialState.paintings[0]).description}</div>
             <hr className="my-4 border-t border-gray-300" />
 
             <div className="flex flex-row justify-evenly">
-              <div>Size: {clientSelectedPainting.sizeX}cm x {clientSelectedPainting.sizeY}cm</div>
-              <div>Price: {clientSelectedPainting.price}€</div>
+              <div>Size: {(selectedPainting ?? initialState.paintings[0]).sizeX}cm x {(selectedPainting ?? initialState.paintings[0]).sizeY}cm</div>
+              <div>Price: {(selectedPainting ?? initialState.paintings[0]).price}€</div>
               <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
                 Buy
               </button>

--- a/store/features/someSlice.ts
+++ b/store/features/someSlice.ts
@@ -1,20 +1,20 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface SomeState {
-  value: number;
+  value: number | null;
 }
 
-const initialState: SomeState = { value: 0 };
+const initialState: SomeState = { value: null };
 
 const someSlice = createSlice({
   name: 'some',
   initialState,
   reducers: {
     increment: (state) => {
-      state.value += 1;
+      state.value = (state.value ?? 0) + 1;
     },
     decrement: (state) => {
-      state.value -= 1;
+      state.value = (state.value ?? 0) - 1;
     },
     setValue: (state, action: PayloadAction<number>) => {
       state.value = action.payload;


### PR DESCRIPTION
## Summary
- remove local `useState` for client painting list and selection
- render from Redux selectors with initial fallback
- refactor about client page to dispatch initial value and read directly from Redux
- allow `someSlice` value to start as `null` so selectors can fall back

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5e811d8608328a89bb73759870510