### PR TITLE
Use store factory with preloaded state

### DIFF
--- a/app/about/clientPage.tsx
+++ b/app/about/clientPage.tsx
@@ -3,20 +3,15 @@
 import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "@/store/store";
 import { increment, decrement, setValue } from "@/store/features/someSlice";
-import { useEffect } from "react";
 
-export default function ClientPage({ initialValue }: { initialValue: number }) {
+export default function ClientPage() {
     const dispatch = useDispatch();
     const reduxValue = useSelector((state: RootState) => state.some.value);
-
-    useEffect(() => {
-        dispatch(setValue(initialValue));
-    }, [dispatch, initialValue]);
 
     return (
         <div>
             <h1>О нас</h1>
-            <h2>{reduxValue ?? initialValue}</h2>
+            <h2>{reduxValue}</h2>
             <button onClick={() => dispatch(increment())}>+</button>
             <button onClick={() => dispatch(decrement())}>-</button>
             <button onClick={() => dispatch(setValue(10))}>Set to 10</button>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,13 +1,21 @@
 import ClientPage from "./clientPage";
+import { Providers } from "@/lib/providers";
+import { RootState } from "@/store/store";
 
 export default async function About() {
   // Данные, которые будут рендериться на сервере
   const initialValue = 5; // Можно получить из API или базы данных
 
+  const preloadedState: Partial<RootState> = {
+    some: { value: initialValue },
+  };
+
   return (
-    <main>
-      <ClientPage initialValue={initialValue} />
-    </main>
+    <Providers initialState={preloadedState}>
+      <main>
+        <ClientPage />
+      </main>
+    </Providers>
   );
 }
 

--- a/app/clientPage.tsx
+++ b/app/clientPage.tsx
@@ -2,60 +2,61 @@
 
 import PaintingPreview from '../components/molecule/PaintingPreview';
 import Painting from '../components/molecule/Painting';
-import { InitialState } from './page';
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 import { RootState } from "@/store/store";
-import { setPaintings } from "@/store/features/paintingsSlice";
-import { useEffect } from "react";
+import { Painting as PaintingType } from '@/interfaces/painting';
 
-export default function ClientPage({ initialState }: { initialState: InitialState }) {
-  const dispatch = useDispatch();
-  const reduxList = useSelector((state: RootState) => state.paintings.list);
-  const selectedPainting = useSelector((state: RootState) => state.paintings.selectedPainting);
-
-  useEffect(() => {
-    dispatch(setPaintings(initialState.paintings));
-  }, [dispatch, initialState.paintings]);
-
+export default function ClientPage() {
+  const reduxList: PaintingType[] = useSelector(
+    (state: RootState) => state.paintings.list
+  );
+  const selectedPainting =
+    useSelector((state: RootState) => state.paintings.selectedPainting) ||
+    reduxList[0];
 
   // fetch("/api/hello")
   // .then((res) => res.json())
   // .then((data) => console.log(data.message));
 
   return (
-    <div style={{ height: "calc(100vh - 4rem)" }} className="p-8 pb-0 sm:p-10 sm:pb-0 gap-16  font-[family-name:var(--font-geist-sans)] w-full max-w-screen-2xl mx-auto">
+    <div
+      style={{ height: "calc(100vh - 4rem)" }}
+      className="p-8 pb-0 sm:p-10 sm:pb-0 gap-16  font-[family-name:var(--font-geist-sans)] w-full max-w-screen-2xl mx-auto"
+    >
       <main className="flex flex-row gap-8 row-start-2 items-center sm:items-start h-full w-full">
-
         {/* left side (paintings list ) */}
         <div className="h-full w-45 overflow-auto scrollbar-hide">
-          {(reduxList.length ? reduxList : initialState.paintings).map((painting, i) => (
+          {reduxList.map((painting, i) => (
             <PaintingPreview key={painting.title + i} data={painting} />
           ))}
         </div>
 
         {/* right side (content) */}
         <div className="h-full w-full overflow-auto scrollbar-hide">
-
           {/* top content (img) */}
-          <Painting data={selectedPainting ?? initialState.paintings[0]} />
+          {selectedPainting && <Painting data={selectedPainting} />}
 
           {/* bottom content (info) */}
-          <div className="bg-gray-600 p-4 rounded-lg shadow-lg">
-            <div><b>{(selectedPainting ?? initialState.paintings[0]).title}</b></div>
-            <div>{(selectedPainting ?? initialState.paintings[0]).description}</div>
-            <hr className="my-4 border-t border-gray-300" />
+          {selectedPainting && (
+            <div className="bg-gray-600 p-4 rounded-lg shadow-lg">
+              <div>
+                <b>{selectedPainting.title}</b>
+              </div>
+              <div>{selectedPainting.description}</div>
+              <hr className="my-4 border-t border-gray-300" />
 
-            <div className="flex flex-row justify-evenly">
-              <div>Size: {(selectedPainting ?? initialState.paintings[0]).sizeX}cm x {(selectedPainting ?? initialState.paintings[0]).sizeY}cm</div>
-              <div>Price: {(selectedPainting ?? initialState.paintings[0]).price}€</div>
-              <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-                Buy
-              </button>
+              <div className="flex flex-row justify-evenly">
+                <div>
+                  Size: {selectedPainting.sizeX}cm x {selectedPainting.sizeY}cm
+                </div>
+                <div>Price: {selectedPainting.price}€</div>
+                <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                  Buy
+                </button>
+              </div>
             </div>
-          </div>
-
+          )}
         </div>
-
       </main>
     </div>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navigation from "@/components/organisms/Navigation";
-import { Providers } from "@/lib/providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,7 +29,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen `}
       >
         <Navigation />
-        <Providers>{children}</Providers>
+        {children}
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,7 @@
 import ClientPage from "./clientPage";
+import { Providers } from "@/lib/providers";
 import { Painting } from '@/interfaces/painting';
-
-export interface InitialState {
-    paintings: Painting[];
-}
+import { RootState } from '@/store/store';
 
 export default async function Home() {
     // Данные, которые будут рендериться на сервере
@@ -62,14 +60,19 @@ export default async function Home() {
         },
     ];
 
-    const initialState: InitialState = {
-        paintings
+    const preloadedState: Partial<RootState> = {
+        paintings: {
+            list: paintings,
+            selectedPainting: null,
+        },
     };
 
     return (
-        <main>
-            <ClientPage initialState={initialState} />
-        </main>
+        <Providers initialState={preloadedState}>
+            <main>
+                <ClientPage />
+            </main>
+        </Providers>
     );
 }
 

--- a/lib/providers.tsx
+++ b/lib/providers.tsx
@@ -2,8 +2,15 @@
 
 import { ReactNode } from "react";
 import { Provider } from "react-redux";
-import { store } from "@/store/store";
+import { makeStore, RootState } from "@/store/store";
 
-export function Providers({ children }: { children: ReactNode }) {
+export function Providers({
+  children,
+  initialState,
+}: {
+  children: ReactNode;
+  initialState?: Partial<RootState>;
+}) {
+  const store = makeStore(initialState);
   return <Provider store={store}>{children}</Provider>;
 }

--- a/store/store.ts
+++ b/store/store.ts
@@ -2,12 +2,21 @@ import { configureStore } from '@reduxjs/toolkit';
 import someReducer from '@/store/features/someSlice';
 import paintingsSlice from '@/store/features/paintingsSlice';
 
-export const store = configureStore({
-  reducer: {
-    some: someReducer,
-    paintings: paintingsSlice,
-  },
-});
+const rootReducer = {
+  some: someReducer,
+  paintings: paintingsSlice,
+};
 
-export type RootState = ReturnType<typeof store.getState>;
-export type AppDispatch = typeof store.dispatch;
+export type RootState = {
+  some: ReturnType<typeof someReducer>;
+  paintings: ReturnType<typeof paintingsSlice>;
+};
+
+export const makeStore = (preloadedState?: Partial<RootState>) =>
+  configureStore({
+    reducer: rootReducer as any,
+    preloadedState,
+  });
+
+export type AppStore = ReturnType<typeof makeStore>;
+export type AppDispatch = AppStore['dispatch'];


### PR DESCRIPTION
## Summary
- replace global store singleton with `makeStore` that accepts optional preloaded state
- create redux store in `Providers` using `makeStore(initialState)` and pass state from server pages
- preload paintings and counter slices on server so client pages render without dispatch effects

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5efa8bbb08328b5f1628edb52af6d