### PR TITLE
feat: reinitialize Redux store per request

### DIFF
--- a/lib/providers.tsx
+++ b/lib/providers.tsx
@@ -1,6 +1,6 @@
 "use client"; // Делаем компонент клиентским
 
-import { ReactNode } from "react";
+import { ReactNode, useMemo } from "react";
 import { Provider } from "react-redux";
 import { makeStore, RootState } from "@/store/store";
 
@@ -11,6 +11,6 @@ export function Providers({
   children: ReactNode;
   initialState?: Partial<RootState>;
 }) {
-  const store = makeStore(initialState);
+  const store = useMemo(() => makeStore(initialState), [initialState]);
   return <Provider store={store}>{children}</Provider>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@reduxjs/toolkit": "^2.5.1",
         "clsx": "^2.1.1",
         "next": "15.1.6",
+        "next-redux-wrapper": "^8.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-redux": "^9.2.0"
@@ -4059,6 +4060,17 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-redux-wrapper": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/next-redux-wrapper/-/next-redux-wrapper-8.1.0.tgz",
+      "integrity": "sha512-2hIau0hcI6uQszOtrvAFqgc0NkZegKYhBB7ZAKiG3jk7zfuQb4E7OV9jfxViqqojh3SEHdnFfPkN9KErttUKuw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "next": ">=9",
+        "react": "*",
+        "react-redux": "*"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@reduxjs/toolkit": "^2.5.1",
     "clsx": "^2.1.1",
     "next": "15.1.6",
+    "next-redux-wrapper": "^8.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-redux": "^9.2.0"

--- a/store/store.ts
+++ b/store/store.ts
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { createWrapper } from 'next-redux-wrapper';
 import someReducer from '@/store/features/someSlice';
 import paintingsSlice from '@/store/features/paintingsSlice';
 
@@ -20,3 +21,5 @@ export const makeStore = (preloadedState?: Partial<RootState>) =>
 
 export type AppStore = ReturnType<typeof makeStore>;
 export type AppDispatch = AppStore['dispatch'];
+
+export const wrapper = createWrapper<AppStore>(() => makeStore());


### PR DESCRIPTION
## Summary
- create a fresh Redux store for each request and expose next-redux-wrapper
- memoize store creation in Providers to prevent cross-request state reuse
- add next-redux-wrapper dependency for SSR hydration support

## Testing
- npm test (fails: Missing script "test")
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68a5f3ea84988328a548f898238f35b9