### PR TITLE
Fix focus outline utility in navigation

### DIFF
--- a/components/organisms/Navigation.tsx
+++ b/components/organisms/Navigation.tsx
@@ -19,7 +19,7 @@ export default function Navigation() {
                     <div className="absolute inset-y-0 left-0 flex items-center sm:hidden">
                         <button
                             type="button"
-                            className="relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:ring-2 focus:ring-white focus:outline-hidden focus:ring-inset"
+                            className="relative inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:ring-2 focus:ring-white focus:outline-none focus:ring-inset"
                             aria-controls="mobile-menu"
                             aria-expanded="false"
                         >
@@ -77,7 +77,7 @@ export default function Navigation() {
                     <div className="absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
                         <button
                             type="button"
-                            className="relative rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800 focus:outline-hidden"
+                            className="relative rounded-full bg-gray-800 p-1 text-gray-400 hover:text-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800 focus:outline-none"
                         >
                             <span className="absolute -inset-1.5"></span>
                             <span className="sr-only">View notifications</span>
@@ -102,7 +102,7 @@ export default function Navigation() {
                             <div>
                                 <button
                                     type="button"
-                                    className="relative flex rounded-full bg-gray-800 text-sm focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800 focus:outline-hidden"
+                                    className="relative flex rounded-full bg-gray-800 text-sm focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800 focus:outline-none"
                                     id="user-menu-button"
                                     aria-expanded="false"
                                     aria-haspopup="true"
@@ -120,7 +120,7 @@ export default function Navigation() {
                             </div>
 
                             <div
-                                className="flex flex-col absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 ring-1 shadow-lg ring-black/5 focus:outline-hidden"
+                                className="flex flex-col absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 ring-1 shadow-lg ring-black/5 focus:outline-none"
                                 role="menu"
                                 aria-orientation="vertical"
                                 aria-labelledby="user-menu-button"


### PR DESCRIPTION
## Summary
- replace invalid `focus:outline-hidden` with `focus:outline-none` in navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a650e5f52883288a5b364dc73e8366