### PR TITLE
Rename Painting component

### DIFF
--- a/components/molecule/Painting.tsx
+++ b/components/molecule/Painting.tsx
@@ -1,14 +1,14 @@
 import Image from "next/image";
 import styles from "./Painting.module.css";
 
-interface PPProps {
+interface PaintingProps {
     data: {
         title: string;
         img: string;
-    }
+    };
 }
 
-export default function PaintingPreview({ data }: PPProps) {
+export default function Painting({ data }: PaintingProps) {
     return (
         <div className="flex justify-center items-center mb-4">
             <div className="relative w-full">


### PR DESCRIPTION
## Summary
- rename component `PaintingPreview` to `Painting`
- rename interface `PPProps` to `PaintingProps` for clarity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a651c9b0cc83288ab7cc9fe945ed4a