### PR TITLE
Fix image sizing and reduce console warnings

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,11 +6,13 @@ import Navigation from "@/components/organisms/Navigation";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  preload: false,
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  preload: false,
 });
 
 export const metadata: Metadata = {

--- a/components/molecule/Painting.module.css
+++ b/components/molecule/Painting.module.css
@@ -5,6 +5,8 @@
 
 .img {
     background-color: rgb(189, 187, 188);
+    width: 100%;
+    height: auto;
     -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 5%, rgba(0, 0, 0, 1) 95%, rgba(0, 0, 0, 0) 100%),
         linear-gradient(to right, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 5%, rgba(0, 0, 0, 1) 95%, rgba(0, 0, 0, 0) 100%);
     mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 5%, rgba(0, 0, 0, 1) 95%, rgba(0, 0, 0, 0) 100%),

--- a/components/molecule/Painting.tsx
+++ b/components/molecule/Painting.tsx
@@ -14,12 +14,13 @@ export default function Painting({ data }: PaintingProps) {
             <div className="relative w-full">
                 <div className={`flex justify-center items-center bg-gray-200 p-2 rounded-lg shadow-lg ${styles.container}`}>
                     <Image
-                        className={`bg-gray-200  rounded-lg shadow-lg ${styles.img}`}
+                        className={`bg-gray-200 rounded-lg shadow-lg ${styles.img}`}
                         src={data.img}
-                        alt="Next.js logo"
-                        width={800}
-                        height={800}
+                        alt={data.title}
+                        width={3716}
+                        height={2960}
                         priority
+                        style={{ width: "100%", height: "auto" }}
                     />
                 </div>
             </div>

--- a/components/molecule/PaintingPreview.module.css
+++ b/components/molecule/PaintingPreview.module.css
@@ -5,6 +5,8 @@
 
 .img {
     background-color: rgb(189, 187, 188);
+    width: 100%;
+    height: auto;
     -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 5%, rgba(0, 0, 0, 1) 95%, rgba(0, 0, 0, 0) 100%),
         linear-gradient(to right, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 5%, rgba(0, 0, 0, 1) 95%, rgba(0, 0, 0, 0) 100%);
     mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 5%, rgba(0, 0, 0, 1) 95%, rgba(0, 0, 0, 0) 100%),

--- a/components/molecule/PaintingPreview.tsx
+++ b/components/molecule/PaintingPreview.tsx
@@ -19,12 +19,13 @@ export default function PaintingPreview({ data }: PPProps) {
             <div className="relative w-full max-w-md">
                 <div className={`flex justify-center items-center bg-gray-200 p-2 rounded-lg shadow-lg ${styles.container}`}>
                     <Image
-                        className={`bg-gray-200  rounded-lg shadow-lg ${styles.img}`}
+                        className={`bg-gray-200 rounded-lg shadow-lg ${styles.img}`}
                         src={data.img}
-                        alt="Next.js logo"
-                        width={180}
-                        height={38}
+                        alt={data.title}
+                        width={3716}
+                        height={2960}
                         priority
+                        style={{ width: "100%", height: "auto" }}
                     />
                 </div>
             </div>

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,13 @@ const nextConfig: NextConfig = {
   images: {
     domains: ["images.unsplash.com"], // Разрешенные источники изображений
   },
+  productionBrowserSourceMaps: false,
+  webpack: (config, { dev }) => {
+    if (dev) {
+      config.devtool = false;
+    }
+    return config;
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- ensure painting components keep image aspect ratio with responsive sizing
- disable unused font preloading and browser sourcemaps to clean up console output

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6542b15808328b7532b3b7a862201