### PR TITLE
Fix hydration mismatch for active nav links

### DIFF
--- a/components/molecule/ActiveLink.tsx
+++ b/components/molecule/ActiveLink.tsx
@@ -12,8 +12,8 @@ interface ActiveLinkProps {
 
 export default function ActiveLink({ href, children }: ActiveLinkProps) {
   const pathname = usePathname();
-  const isActive = pathname === href || pathname.startsWith(href + "/");
 
+  const [isActive, setIsActive] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
@@ -28,6 +28,12 @@ export default function ActiveLink({ href, children }: ActiveLinkProps) {
       window.removeEventListener("resize", checkScreenSize);
     };
   }, []);
+
+  useEffect(() => {
+    if (!pathname) return;
+
+    setIsActive(pathname === href || pathname.startsWith(href + "/"));
+  }, [pathname, href]);
 
   return (
     <Link


### PR DESCRIPTION
## Summary
- delay active link check until client path is available to prevent hydration mismatch

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a65b25ba808328bd0624709d329319